### PR TITLE
[Hotfix] Sticky panel infinite recursion

### DIFF
--- a/src/Oro/Bundle/FrontendBundle/Resources/public/default/js/app/views/sticky-panel-view.js
+++ b/src/Oro/Bundle/FrontendBundle/Resources/public/default/js/app/views/sticky-panel-view.js
@@ -172,7 +172,7 @@ define(function(require) {
 
             if (contentChanged) {
                 this.$el.toggleClass('has-content', this.$el.find('.' + this.options.elementClass).length > 0);
-                this.onScroll();
+                window.requestAnimationFrame(this.onScroll.bind(this));
             }
         },
 


### PR DESCRIPTION
While scrolling up and down very fast when a sticky menu is present, the script freezes the page about 10 seconds and a recursion error appears.

I removed the recursion and made use of `window.requestAnimationFrame` method instead, which is more suited for this and guarantees to exit scope and relaunch the call 60 times/sec maximum on viewport redraw.