### PR TITLE
0% tax resolves an order into a 500 division by 0

### DIFF
--- a/src/Oro/Bundle/TaxBundle/Resolver/RowTotalResolver.php
+++ b/src/Oro/Bundle/TaxBundle/Resolver/RowTotalResolver.php
@@ -56,17 +56,24 @@ class RowTotalResolver
 
         foreach ($taxRules as $taxRule) {
             $currentTaxRate = BigDecimal::of($taxRule->getTax()->getRate());
-            $taxResults[] = TaxResultElement::create(
-                $taxRule->getTax(),
-                $currentTaxRate,
-                $resultElementStartWith->getExcludingTax(),
-                BigDecimal::of($resultElementStartWith->getTaxAmount())
+            
+            if (BigDecimal::zero()->isEqualTo($currentTaxRate) || BigDecimal::zero()->isEqualTo($resultElementStartWith)) {
+                $taxAmount = BigDecimal::zero();
+            } else {
+                $taxAmount = BigDecimal::of($resultElementStartWith->getTaxAmount())
                     ->multipliedBy($currentTaxRate->toScale(TaxationSettingsProvider::CALCULATION_SCALE))
                     ->dividedBy(
                         $taxRate->toScale(TaxationSettingsProvider::CALCULATION_SCALE),
                         TaxationSettingsProvider::CALCULATION_SCALE,
                         RoundingMode::HALF_UP
-                    )
+                    );
+            }
+
+            $taxResults[] = TaxResultElement::create(
+                $taxRule->getTax(),
+                $currentTaxRate,
+                $resultElementStartWith->getExcludingTax(),
+                $taxAmount
             );
         }
 


### PR DESCRIPTION
If there is a tax rule using 0% the orders gets thrown into a 500 error because of a division by zero bug.
Added a check on the amount on tax / taxable amount.