### PR TITLE
Removed type declaration

### DIFF
--- a/src/Oro/Bundle/PricingBundle/Model/PriceListTreeHandler.php
+++ b/src/Oro/Bundle/PricingBundle/Model/PriceListTreeHandler.php
@@ -76,11 +76,15 @@ class PriceListTreeHandler
      * @param Website|null $website
      * @return CombinedPriceList|null
      */
-    public function getPriceList(Customer $customer = null, Website $website = null)
+    public function getPriceList(Customer $customer = null, $website = null)
     {
         if (!$website) {
             $website = $this->websiteManager->getCurrentWebsite();
         }
+        if (!$website) {
+            $website = $this->websiteManager->getDefaultWebsite();
+        }
+
 
         $key = $this->getUniqueKey($customer, $website);
         if (array_key_exists($key, $this->priceLists)) {


### PR DESCRIPTION
We had this break on the commandline, when called withoud website. This is probably because of another error where i removed the website from the customer. That broke somewhere.

But this does nog resolve the website to a default. And the website is not needed on ce because ce only uses 1 website.

Type Declarations breaks when a website is null.
 When called on a commandline the current website does nog give a website instance because it is not a frontend call, so i added the default website as fallback.

This is not a solution, just a patch probably.