### PR TITLE
Register VSA Paypal partner ID

### DIFF
--- a/src/Oro/Bundle/PayPalBundle/PayPal/Payflow/Option/Partner.php
+++ b/src/Oro/Bundle/PayPalBundle/PayPal/Payflow/Option/Partner.php
@@ -36,6 +36,7 @@ class Partner extends AbstractOption
     const VITA = 'VITA';
     const TELN = 'TELN';
     const FIFT = 'FIFT';
+    const VSA  = 'VSA';
     const WPAY = 'WPAY';
     const PAYPAL = Processor\PayPal::CODE;
     const PAYPALCA = Processor\PayPalCA::CODE;
@@ -64,6 +65,7 @@ class Partner extends AbstractOption
         Partner::VITA => 'TSYS',
         Partner::TELN => 'TeleCheck 2',
         Partner::FIFT => 'Vantiv',
+        Partner::VSA  => 'VSA',
         Partner::WPAY => 'World Pay',
     ];
 


### PR DESCRIPTION
The current OroCommerce <> PayPal PayFlow integration configuration does not support Australian PayPal accounts which have the Partner ID: VSA. I have registered this new PayPal Partner ID to cater for any Australian business which uses the Oro Commerce platform.