### PR TITLE
Fix Typo in SaleBundle Validation Message

### DIFF
--- a/src/Oro/Bundle/SaleBundle/Resources/translations/validators.en.yml
+++ b/src/Oro/Bundle/SaleBundle/Resources/translations/validators.en.yml
@@ -16,4 +16,4 @@ oro:
                     blank: 'Please enter valid quantity'
                 quantity:
                     equal: 'Quantity should be equal to offered quantity'
-                    less: 'Quantity should be grater than or equal to offered quantity'
+                    less: 'Quantity should be greater than or equal to offered quantity'

--- a/src/Oro/Bundle/SaleBundle/Tests/Functional/Controller/Frontend/QuoteControllerTest.php
+++ b/src/Oro/Bundle/SaleBundle/Tests/Functional/Controller/Frontend/QuoteControllerTest.php
@@ -807,7 +807,7 @@ class QuoteControllerTest extends WebTestCase
         $this->assertCount(
             1,
             $crawler->filter(
-                '.validation-failed:contains("Quantity should be grater than or equal to offered quantity")'
+                '.validation-failed:contains("Quantity should be greater than or equal to offered quantity")'
             )
         );
     }


### PR DESCRIPTION
Change 'grater' to 'greater' (translation + functional test)

Fixes #91 