### PR TITLE
Fix the tearDown() in ProductVariantAvailabilityProviderTest

### DIFF
--- a/src/Oro/Bundle/ProductBundle/Tests/Unit/Provider/ProductVariantAvailabilityProviderTest.php
+++ b/src/Oro/Bundle/ProductBundle/Tests/Unit/Provider/ProductVariantAvailabilityProviderTest.php
@@ -155,13 +155,13 @@ class ProductVariantAvailabilityProviderTest extends \PHPUnit\Framework\TestCase
     public function tearDown()
     {
         unset(
-            $availabilityProvider,
-            $productRepository,
-            $qb,
-            $query,
-            $customFieldProvider,
-            $enumHandler,
-            $dispatcher
+            $this->availabilityProvider,
+            $this->productRepository,
+            $this->qb,
+            $this->query,
+            $this->customFieldProvider,
+            $this->enumHandler,
+            $this->dispatcher
         );
     }
 


### PR DESCRIPTION
It was previously unsetting undefined variables instead of the class
fields.

