### PR TITLE
Fix pagination links not beeing rendered correctly due to variable overwritte

### DIFF
--- a/src/Oro/Bundle/ProductBundle/Resources/views/layouts/blank/imports/oro_datagrid_server_render/server_render_datagrid_toolbar.html.twig
+++ b/src/Oro/Bundle/ProductBundle/Resources/views/layouts/blank/imports/oro_datagrid_server_render/server_render_datagrid_toolbar.html.twig
@@ -61,8 +61,8 @@
                    data-grid-pagination-trigger-input/>
 
             <span class="oro-pagination__total">
-                {% set totalPages = '<span data-grid-pagination-pages>' ~ totalPages ~ '</span>' %}
-                {{ "oro.datagrid.pagination.totalPages"|trans({'%totalPages%': totalPages})|raw }}
+                {% set totalPagesWithAMarkup = '<span data-grid-pagination-pages>' ~ totalPages ~ '</span>' %}
+                {{ "oro.datagrid.pagination.totalPages"|trans({'%totalPages%': totalPagesWithAMarkup})|raw }}
             </span>
 
             <a href="{% if currentPage >= totalPages %}#{% else %}{{ oro_datagrid_get_page_url(datagrid, currentPage + 1) }}{% endif %}"


### PR DESCRIPTION
TotalPages variable gets redeclared with markup included, this causes Next page link not to work correctly (# is displayed instead of a link)