### PR TITLE
Fix Category TreeRoot identifierMethod loading

### DIFF
--- a/src/Oro/Bundle/CatalogBundle/Entity/Category.php
+++ b/src/Oro/Bundle/CatalogBundle/Entity/Category.php
@@ -339,7 +339,7 @@ class Category extends ExtendCategory implements SluggableInterface, DatesAwareI
     /**
      * @var integer
      *
-     * @Gedmo\TreeRoot
+     * @Gedmo\TreeRoot(identifierMethod="getRoot")
      * @ORM\Column(name="tree_root", type="integer", nullable=true)
      * @ConfigField(
      *      defaultValues={

--- a/src/Oro/Component/Tree/Entity/TreeTrait.php
+++ b/src/Oro/Component/Tree/Entity/TreeTrait.php
@@ -34,7 +34,7 @@ trait TreeTrait
     /**
      * @var integer
      *
-     * @Gedmo\TreeRoot
+     * @Gedmo\TreeRoot(identifierMethod="getRoot")
      * @ORM\Column(name="tree_root", type="integer", nullable=true)
      */
     protected $root;


### PR DESCRIPTION
Hi,
While using reorderAll method of NestedTreeRepository, I got the following error : 
```
In NestedTreeRepository.php line 431:   
  Method name must be a string 
```
It was due to an not implemented variable of TreeRoot class :  identifierMethod

Adding the getRoot method in annotation for the identifierMethod solve the problem.