### PR TITLE
Simple native raw string replacement with PHP best practices through …

### DIFF
--- a/src/Oro/Bundle/CatalogBundle/Twig/CategoryImageExtension.php
+++ b/src/Oro/Bundle/CatalogBundle/Twig/CategoryImageExtension.php
@@ -17,6 +17,9 @@ use Twig\TwigFunction;
  */
 class CategoryImageExtension extends AbstractExtension implements ServiceSubscriberInterface
 {
+    /** @const ORO_CATALOG_CATEGORY_IMAGE_EXTENSION */
+    public const ORO_CATALOG_CATEGORY_IMAGE_EXTENSION = 'oro_catalog_category_image_extension';
+    
     /** @var ContainerInterface */
     private $container;
 
@@ -71,7 +74,7 @@ class CategoryImageExtension extends AbstractExtension implements ServiceSubscri
      */
     public function getName()
     {
-        return 'oro_catalog_category_image_extension';
+        return self::ORO_CATALOG_CATEGORY_IMAGE_EXTENSION;
     }
 
     /**


### PR DESCRIPTION
…a constant

This version requires Symfony 4.4.*, which requires PHP 7.1.3+, which is over 7.1.0 for class constants visibility.

Could be the same for container parameters one day, but they're keys, not simple strings.