### PR TITLE
remove the setLogger method as it already exist in the LoggerAwareTrait

### DIFF
--- a/src/Oro/Bundle/CMSBundle/ContentBlock/ContentBlockRenderer.php
+++ b/src/Oro/Bundle/CMSBundle/ContentBlock/ContentBlockRenderer.php
@@ -38,11 +38,6 @@ class ContentBlockRenderer implements LoggerAwareInterface
         $this->logger = new NullLogger();
     }
 
-    public function setLogger(LoggerInterface $logger): void
-    {
-        $this->logger = $logger;
-    }
-
     public function render(string $blockAlias): string
     {
         $content = '';


### PR DESCRIPTION
Hi,

In the src/Oro/Bundle/CMSBundle/ContentBlock/ContentBlockRenderer.php there is duplicated code, we rewrite the method setLogger, but a Trait with this method is already used : LoggerAwareTrait.