### PR TITLE
Add cron namespace to the command

### DIFF
--- a/src/Oro/Bundle/WebsiteSearchBundle/Command/ActualizeSearchTermReportCronCommand.php
+++ b/src/Oro/Bundle/WebsiteSearchBundle/Command/ActualizeSearchTermReportCronCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ActualizeSearchTermReportCronCommand extends Command implements CronCommandScheduleDefinitionInterface
 {
     /** @var string */
-    protected static $defaultName = 'oro:website-search:actualize-search-term-report';
+    protected static $defaultName = 'oro:cron:website-search:actualize-search-term-report';
 
     private SearchResultHistoryManagerInterface $manager;
 

--- a/src/Oro/Bundle/WebsiteSearchBundle/Resources/config/oro/features.yml
+++ b/src/Oro/Bundle/WebsiteSearchBundle/Resources/config/oro/features.yml
@@ -7,7 +7,7 @@ features:
             - 'oro_website_search_result_history_index'
             - 'oro_website_search_term_preview'
         commands:
-            - 'oro:website-search:actualize-search-term-report'
+            - 'oro:cron:website-search:actualize-search-term-report'
         entities:
             - 'Oro\Bundle\WebsiteSearchBundle\SearchResult\Entity\SearchResultHistory'
             - 'Oro\Bundle\WebsiteSearchBundle\SearchResult\Entity\SearchTermReport'

--- a/src/Oro/Bundle/WebsiteSearchBundle/Tests/Functional/Command/ActualizeSearchTermReportCronCommandTest.php
+++ b/src/Oro/Bundle/WebsiteSearchBundle/Tests/Functional/Command/ActualizeSearchTermReportCronCommandTest.php
@@ -33,7 +33,7 @@ class ActualizeSearchTermReportCronCommandTest extends WebTestCase
         $this->assertEquals(0, $reportRepo->count([]));
         $this->assertEquals(9, $historyRepo->count([]));
 
-        $this->runCommand('oro:website-search:actualize-search-term-report');
+        $this->runCommand('oro:cron:website-search:actualize-search-term-report');
 
         $this->assertEquals(6, $reportRepo->count([]));
         $this->assertEquals(5, $historyRepo->count([]));


### PR DESCRIPTION
Currently the command isnt being executed with other cron commands. As per docs it should have "oro:cron" namespace:

https://doc.oroinc.com/backend/cron/

> A scheduled command in OroPlatform is a regular Symfony console command that implements additional [CronCommandScheduleDefinitionInterface](https://github.com/oroinc/platform/blob/master/src/Oro/Bundle/CronBundle/Command/CronCommandScheduleDefinitionInterface.php) and has the oro:cron namespace.