### PR TITLE
FIX: label-on-tablet-end margin in responsive-shopping-list-grid

### DIFF
--- a/src/Oro/Bundle/ShoppingListBundle/Resources/public/default/scss/components/responsive-shopping-list-grid/responsive-shopping-list-grid.scss
+++ b/src/Oro/Bundle/ShoppingListBundle/Resources/public/default/scss/components/responsive-shopping-list-grid/responsive-shopping-list-grid.scss
@@ -203,7 +203,12 @@
     .label-on-tablet-end::after {
         content: attr(data-label);
         color: $grid-line-field-label-color;
+    }
+    .label-on-tablet-start::before {
         margin-right: $grid-line-field-label-offset;
+    }
+    .label-on-tablet-end::after {
+        margin-left: $grid-line-field-label-offset;
     }
 
     .sub-row {


### PR DESCRIPTION
When using the `label-on-tablet-end` class in the shopping list datagrid at tablet resolution, the label is correctly placed on the right, but the margin is also applied to the right, causing the label to appear too close to the value.